### PR TITLE
fix bash function

### DIFF
--- a/zl.sh
+++ b/zl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 function zl {
-  cd "${zipline}"
+  cd "$(zipline)"
 }


### PR DESCRIPTION
${zipline} will expand the variable $zipline, whereas $(zipline) will call the zipline program/function/alias as with backticks.

Hope this helps!

Thanks for the repo, found it through your article "The Obligations of Perl" on davorg's site.