### PR TITLE
Single key entry

### DIFF
--- a/zl.sh
+++ b/zl.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
 function zl {
-  cd "$(zipline)"
+  local choice
+  choice="$(zipline)"
+  if [ -n "$choice" ]; then
+      echo "$choice"
+      cd "$choice"
+  fi
 }


### PR DESCRIPTION
One more PR for your consideration -- this one allows selection with a single keypress when possible. For directories deeper than 10 levels, `readline` is used as before.

This changeset also includes updates to the shell function ignore an empty response from `zipline` and to print the selection/target before changing directories.